### PR TITLE
aarch64: check for LITTLE cores

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,6 +134,15 @@ class ExtensionBuilder(distutils.command.build_ext.build_ext, build_ext_options)
     def get_arch_name(self):
         if "BLIS_ARCH" in os.environ:
             return os.environ["BLIS_ARCH"]
+        machine = os.uname()[4]
+        if machine == "aarch64":
+            # Check if this is a LITTLE core.
+            LITTLE_core = os.system("test 'Cortex-A53' = $(lscpu | grep 'Model name' | awk '{print $3}')")
+            if LITTLE_core == 0:
+                return "cortexa53"
+            else:
+                # Optimize for big cores.
+                return "cortexa57"
         else:
             return "x86_64"
 


### PR DESCRIPTION
This is a fix for bug #13 
This patch adds logic to setup.py to detect aarch64 LITTLE cores for which BLIS has configure flag BLIS_ARCH="cortexa53".
All other cores will configure with BLIS_ARCH="cortexa57".
