### PR TITLE
check for windows before calling os.uname()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ class ExtensionBuilder(distutils.command.build_ext.build_ext, build_ext_options)
     def get_arch_name(self):
         if "BLIS_ARCH" in os.environ:
             return os.environ["BLIS_ARCH"]
-        machine = os.uname()[4]
+        machine = platform.uname()[4]
         if machine == "aarch64":
             # Check if this is a LITTLE core.
             LITTLE_core = os.system("test 'Cortex-A53' = $(lscpu | grep 'Model name' | awk '{print $3}')")


### PR DESCRIPTION
os.uname() only exists on Unix systems.