### PR TITLE
Warn and exit when compiling blis for pip <19.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -209,6 +209,17 @@ SRC = os.path.join(PWD, "blis")
 BLIS_DIR = os.path.join(SRC, "_src")
 INCLUDE = os.path.join(PWD, "blis", "_src", "include")
 COMPILER = os.environ.get("BLIS_COMPILER", "gcc")
+BLIS_REALLY_COMPILE = os.environ.get("BLIS_REALLY_COMPILE", 0)
+
+if not BLIS_REALLY_COMPILE:
+    try:
+        import pip
+        major = int(pip.__version__.split(".", 1)[0])
+        if major < 19:
+            print("WARNING: pip versions <19.0 (currently installed: " + pip.__version__ + ") are unable to detect binary wheel compatibility for blis. To avoid a source install with a very long compilation time, please upgrade pip with `pip install --upgrade pip`.\n\nIf you know what you're doing and you really want to compile blis from source, please set the environment variable BLIS_REALLY_COMPILE=1.")
+            sys.exit(1)
+    except Exception:
+        pass
 
 c_files = []  # get_c_sources(SRC)
 

--- a/setup.py
+++ b/setup.py
@@ -214,9 +214,11 @@ BLIS_REALLY_COMPILE = os.environ.get("BLIS_REALLY_COMPILE", 0)
 if not BLIS_REALLY_COMPILE:
     try:
         import pip
-        major = int(pip.__version__.split(".", 1)[0])
-        if major < 19:
-            print("WARNING: pip versions <19.0 (currently installed: " + pip.__version__ + ") are unable to detect binary wheel compatibility for blis. To avoid a source install with a very long compilation time, please upgrade pip with `pip install --upgrade pip`.\n\nIf you know what you're doing and you really want to compile blis from source, please set the environment variable BLIS_REALLY_COMPILE=1.")
+        version_parts = pip.__version__.split(".")
+        major = int(version_parts[0])
+        minor = int(version_parts[1])
+        if major < 19 or (major == 19 and minor < 3):
+            print("WARNING: pip versions <19.3 (currently installed: " + pip.__version__ + ") are unable to detect binary wheel compatibility for blis. To avoid a source install with a very long compilation time, please upgrade pip with `pip install --upgrade pip`.\n\nIf you know what you're doing and you really want to compile blis from source, please set the environment variable BLIS_REALLY_COMPILE=1.")
             sys.exit(1)
     except Exception:
         pass


### PR DESCRIPTION
This attempts to check for `pip<19.0` in order to warn users that upgrading `pip` is probably the solution they want rather than compiling `blis` from source. Based on what Matt has said, I think this check would work for `manylinux2010`. For `manylinux2014`, we'd need to modify this to check for `19.1` instead of `19.0`.

If anything goes wrong while checking the version (the check is not at all robust), it will ignore any errors and keep going.