### PR TITLE
Add cdef nogil sgemm and saxpy functions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ jobs:
         imageName: 'macos-10.15'
         python.version: '3.6'
       Python36Windows:
-        imageName: 'windows-latest'
+        imageName: 'windows-2019'
         python.version: '3.6'
       Python37Linux:
         imageName: 'ubuntu-18.04'

--- a/blis/cy.pxd
+++ b/blis/cy.pxd
@@ -180,3 +180,12 @@ cdef void randv(
     dim_t m,
     reals_ft x, inc_t incx
 ) nogil
+
+
+cdef void sgemm(bint transA, bint transB, int M, int N, int K,
+                float alpha, const float* A, int lda, const float *B,
+                int ldb, float beta, float* C, int ldc) nogil
+
+
+cdef void saxpy(int N, float alpha, const float* X, int incX,
+                float *Y, int incY) nogil

--- a/blis/cy.pxd
+++ b/blis/cy.pxd
@@ -182,10 +182,19 @@ cdef void randv(
 ) nogil
 
 
+cdef void dgemm(bint transA, bint transB, int M, int N, int K,
+                double alpha, const double* A, int lda, const double* B,
+                int ldb, double beta, double* C, int ldc) nogil
+
+
 cdef void sgemm(bint transA, bint transB, int M, int N, int K,
-                float alpha, const float* A, int lda, const float *B,
+                float alpha, const float* A, int lda, const float* B,
                 int ldb, float beta, float* C, int ldc) nogil
 
 
+cdef void daxpy(int N, double alpha, const double* X, int incX,
+                double* Y, int incY) nogil
+
+
 cdef void saxpy(int N, float alpha, const float* X, int incX,
-                float *Y, int incY) nogil
+                float* Y, int incY) nogil

--- a/blis/cy.pyx
+++ b/blis/cy.pyx
@@ -600,8 +600,21 @@ cdef void sumsqv(dim_t   m, reals_ft  x, inc_t incx,
             raise ValueError("Unhandled fused type")
 
 
+cdef void dgemm(bint transA, bint transB, int M, int N, int K,
+                double alpha, const double* A, int lda, const double* B,
+                int ldb, double beta, double* C, int ldc) nogil:
+    gemm(
+        TRANSPOSE if transA else NO_TRANSPOSE,
+        TRANSPOSE if transB else NO_TRANSPOSE,
+        M, N, K,
+        alpha, A, lda, 1,
+        B, ldb, 1,
+        beta, C, ldc, 1
+    )
+
+
 cdef void sgemm(bint transA, bint transB, int M, int N, int K,
-                float alpha, const float* A, int lda, const float *B,
+                float alpha, const float* A, int lda, const float* B,
                 int ldb, float beta, float* C, int ldc) nogil:
     gemm(
         TRANSPOSE if transA else NO_TRANSPOSE,
@@ -614,7 +627,12 @@ cdef void sgemm(bint transA, bint transB, int M, int N, int K,
 
 
 cdef void saxpy(int N, float alpha, const float* X, int incX,
-                float *Y, int incY) nogil:
+                float* Y, int incY) nogil:
+    axpyv(NO_CONJUGATE, N, alpha, X, incX, Y, incY)
+
+
+cdef void daxpy(int N, double alpha, const double* X, int incX,
+                double* Y, int incY) nogil:
     axpyv(NO_CONJUGATE, N, alpha, X, incX, Y, incY)
 
 

--- a/blis/cy.pyx
+++ b/blis/cy.pyx
@@ -600,6 +600,24 @@ cdef void sumsqv(dim_t   m, reals_ft  x, inc_t incx,
             raise ValueError("Unhandled fused type")
 
 
+cdef void sgemm(bint transA, bint transB, int M, int N, int K,
+                float alpha, const float* A, int lda, const float *B,
+                int ldb, float beta, float* C, int ldc) nogil:
+    gemm(
+        TRANSPOSE if transA else NO_TRANSPOSE,
+        TRANSPOSE if transB else NO_TRANSPOSE,
+        M, N, K,
+        alpha, A, lda, 1,
+        B, ldb, 1,
+        beta, C, ldc, 1
+    )
+
+
+cdef void saxpy(int N, float alpha, const float* X, int incX,
+                float *Y, int incY) nogil:
+    axpyv(NO_CONJUGATE, N, alpha, X, incX, Y, incY)
+
+
 @atexit.register
 def finalize():
     bli_finalize()


### PR DESCRIPTION
The motivation for adding these functions is to be able to use them from `cdef nogil` code from different BLAS implementations interchangeably. The signature mirrors CBLAS as closely as possible, with the following simplifications to `sgemm`:

- Remove the order argument, always assume C-order.
- Since a conjugate transpose is not possible on a float matrix, specify transpose using booleans.

We also use 32-bit integer sizes and increments as the lowest-common denominator of different BLAS versions.
