### PR TITLE
gemm: use uninitialized array when beta is zero

### DIFF
--- a/blis/py.pyx
+++ b/blis/py.pyx
@@ -75,7 +75,10 @@ def gemm(const_reals2d_ft A, const_reals2d_ft B,
 
     if const_reals2d_ft is const_float2d_t:
         if out is None:
-            out = numpy.zeros((nM, nN), dtype='f')
+            if beta == 0.:
+                out = numpy.empty((nM, nN), dtype='f')
+            else:
+                out = numpy.zeros((nM, nN), dtype='f')
         C = <float*>out.data
         with nogil:
             cy.gemm(


### PR DESCRIPTION
This avoids memsetting the memory if we are going to overwrite it anyway. Profile before the change (`memset` highlighted):

<img width="1392" alt="before-memset-change" src="https://user-images.githubusercontent.com/49398/174624728-c810cc2e-1e44-4f6f-bddb-31b89ac15b56.png">

Profile after the change:

<img width="1392" alt="after-memset-change" src="https://user-images.githubusercontent.com/49398/174624786-869e103d-d84d-49b4-8342-26b0cd9a3b72.png">

The performance on `de_core_news_lg` on a Ryzen 5950X seems to increase from ~21300 WPS to ~24100 WPS.