### PR TITLE
align with BSD OSI template

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,4 @@
-NOTE: Portions of this project's code are copyrighted by
-
-  The University of Texas at Austin
-
-while other portions are copyrighted by
-
-  Hewlett Packard Enterprise Development LP
-  Advanced Micro Devices, Inc.
-  ExplosionAI GmbH
-
-with some overlap. Please see file-level license headers for file-specific
-copyright info. All parties provide their portions of the code under the
-3-clause BSD license, found below.
-
----
-
-Copyright (C) 2018, The University of Texas at Austin
-Copyright (C) 2016, Hewlett Packard Enterprise Development LP
-Copyright (C) 2018, Advanced Micro Devices, Inc.
+Copyright (C) 2018, The University of Texas at Austin, 2016, Hewlett Packard Enterprise , 2018, Advanced Micro Devices, Inc.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are


### PR DESCRIPTION
This ensures that GitHub can properly detect the license:

```
licensee detect .
License:        BSD-3-Clause
Matched files:  LICENSE
LICENSE:
  Content hash:  64030e858d08e2b9b2a8cae5cc61334fd986c5dd
  Attribution:   Copyright (C) 2018, The University of Texas at Austin, 2016, Hewlett Packard Enterprise , 2018, Advanced Micro Devices, Inc.
  Confidence:    99.58%
  Matcher:       Licensee::Matchers::Dice
  License:       BSD-3-Clause
  Closest non-matching licenses:
    BSD-3-Clause similarity:        99.58%
    BSD-4-Clause similarity:        86.76%
    BSD-3-Clause-Clear similarity:  85.30%
```