### PR TITLE
Mark Cython functions as `noexcept` explicitly

### DIFF
--- a/blis/cy.pxd
+++ b/blis/cy.pxd
@@ -102,7 +102,7 @@ cdef void gemm(
     reals_ft  b, inc_t rsb, inc_t csb,
     double  beta,
     reals_ft  c, inc_t rsc, inc_t csc,
-) nogil
+) noexcept nogil
 
 
 cdef void ger(
@@ -114,7 +114,7 @@ cdef void ger(
     reals_ft  x, inc_t incx,
     reals_ft  y, inc_t incy,
     reals_ft  a, inc_t rsa, inc_t csa
-) nogil
+) noexcept nogil
 
 
 cdef void gemv(
@@ -127,7 +127,7 @@ cdef void gemv(
     reals_ft  x, inc_t incx,
     real_ft  beta,
     reals_ft  y, inc_t incy
-) nogil
+) noexcept nogil
 
 
 cdef void axpyv(
@@ -136,7 +136,7 @@ cdef void axpyv(
     real_ft  alpha,
     reals_ft  x, inc_t incx,
     reals_ft  y, inc_t incy
-) nogil
+) noexcept nogil
 
 
 cdef void scalv(
@@ -144,7 +144,7 @@ cdef void scalv(
     dim_t   m,
     real_ft  alpha,
     reals_ft  x, inc_t incx
-) nogil
+) noexcept nogil
 
 
 cdef double dotv(
@@ -155,46 +155,46 @@ cdef double dotv(
     reals_ft y,
     inc_t incx,
     inc_t incy,
-) nogil
+) noexcept nogil
 
 
 cdef double norm_L1(
     dim_t n,
     reals_ft x, inc_t incx
-) nogil
+) noexcept nogil
 
 
 cdef double norm_L2(
     dim_t n,
     reals_ft x, inc_t incx
-) nogil
+) noexcept nogil
 
 
 cdef double norm_inf(
     dim_t n,
     reals_ft x, inc_t incx
-) nogil
+) noexcept nogil
 
 
 cdef void randv(
     dim_t m,
     reals_ft x, inc_t incx
-) nogil
+) noexcept nogil
 
 
 cdef void dgemm(bint transA, bint transB, int M, int N, int K,
                 double alpha, const double* A, int lda, const double* B,
-                int ldb, double beta, double* C, int ldc) nogil
+                int ldb, double beta, double* C, int ldc) noexcept nogil
 
 
 cdef void sgemm(bint transA, bint transB, int M, int N, int K,
                 float alpha, const float* A, int lda, const float* B,
-                int ldb, float beta, float* C, int ldc) nogil
+                int ldb, float beta, float* C, int ldc) noexcept nogil
 
 
 cdef void daxpy(int N, double alpha, const double* X, int incX,
-                double* Y, int incY) nogil
+                double* Y, int incY) noexcept nogil
 
 
 cdef void saxpy(int N, float alpha, const float* X, int incX,
-                float* Y, int incY) nogil
+                float* Y, int incY) noexcept nogil

--- a/blis/cy.pyx
+++ b/blis/cy.pyx
@@ -261,7 +261,7 @@ cdef extern from "blis.h" nogil:
         float*  sumsq,
         blis_cntx_t* cntx,
         blis_rntm_t* rntm,
-    ) nogil
+    ) noexcept nogil
 
     void bli_dsumsqv_ex(
         dim_t   m,
@@ -270,7 +270,7 @@ cdef extern from "blis.h" nogil:
         double*  sumsq,
         blis_cntx_t* cntx,
         blis_rntm_t* rntm,
-    ) nogil
+    ) noexcept nogil
 
 
 
@@ -312,7 +312,7 @@ cdef void gemm(
     reals_ft  b, inc_t rsb, inc_t csb,
     double  beta,
     reals_ft  c, inc_t rsc, inc_t csc
-) nogil:
+) noexcept nogil:
     cdef float alpha_f = alpha
     cdef float beta_f = beta
     cdef double alpha_d = alpha
@@ -353,7 +353,7 @@ cdef void ger(
     reals_ft  x, inc_t incx,
     reals_ft  y, inc_t incy,
     reals_ft  a, inc_t rsa, inc_t csa
-) nogil:
+) noexcept nogil:
     cdef float alpha_f = alpha
     cdef double alpha_d = alpha
     if reals_ft is floats_t:
@@ -395,7 +395,7 @@ cdef void gemv(
     reals_ft  x, inc_t incx,
     real_ft  beta,
     reals_ft  y, inc_t incy
-) nogil:
+) noexcept nogil:
     cdef float alpha_f = alpha
     cdef double alpha_d = alpha
     cdef float beta_f = alpha
@@ -439,7 +439,7 @@ cdef void axpyv(
     real_ft  alpha,
     reals_ft  x, inc_t incx,
     reals_ft  y, inc_t incy
-) nogil:
+) noexcept nogil:
     cdef float alpha_f = alpha
     cdef double alpha_d = alpha
     if reals_ft is floats_t:
@@ -460,7 +460,7 @@ cdef void scalv(
     dim_t   m,
     real_ft  alpha,
     reals_ft  x, inc_t incx
-) nogil:
+) noexcept nogil:
     cdef float alpha_f = alpha
     cdef double alpha_d = alpha
     if reals_ft is floats_t:
@@ -479,7 +479,7 @@ cdef void scalv(
 cdef double norm_L1(
     dim_t n,
     reals_ft x, inc_t incx
-) nogil:
+) noexcept nogil:
     cdef double dnorm = 0
     cdef float snorm = 0
     if reals_ft is floats_t:
@@ -501,7 +501,7 @@ cdef double norm_L1(
 cdef double norm_L2(
     dim_t n,
     reals_ft x, inc_t incx
-) nogil:
+) noexcept nogil:
     cdef double dnorm = 0
     cdef float snorm = 0
     if reals_ft is floats_t:
@@ -523,7 +523,7 @@ cdef double norm_L2(
 cdef double norm_inf(
     dim_t n,
     reals_ft x, inc_t incx
-) nogil:
+) noexcept nogil:
     cdef double dnorm = 0
     cdef float snorm = 0
     if reals_ft is floats_t:
@@ -550,7 +550,7 @@ cdef double dotv(
     reals_ft y,
     inc_t incx,
     inc_t incy,
-) nogil:
+) noexcept nogil:
     cdef double rho_d = 0.0
     cdef float rho_f = 0.0
     if reals_ft is floats_t:
@@ -571,7 +571,7 @@ cdef double dotv(
         raise ValueError("Unhandled fused type")
 
 
-cdef void randv(dim_t m, reals_ft x, inc_t incx) nogil:
+cdef void randv(dim_t m, reals_ft x, inc_t incx) noexcept nogil:
     if reals_ft is floats_t:
         bli_srandv_ex(m, x, incx, NULL, &rntm)
     elif reals_ft is float1d_t:
@@ -586,7 +586,7 @@ cdef void randv(dim_t m, reals_ft x, inc_t incx) nogil:
 
 
 cdef void sumsqv(dim_t   m, reals_ft  x, inc_t incx,
-        reals_ft scale, reals_ft sumsq) nogil:
+        reals_ft scale, reals_ft sumsq) noexcept nogil:
     if reals_ft is floats_t:
         bli_ssumsqv_ex(m, &x[0], incx, scale, sumsq, NULL, &rntm)
     elif reals_ft is float1d_t:
@@ -602,7 +602,7 @@ cdef void sumsqv(dim_t   m, reals_ft  x, inc_t incx,
 
 cdef void dgemm(bint transA, bint transB, int M, int N, int K,
                 double alpha, const double* A, int lda, const double* B,
-                int ldb, double beta, double* C, int ldc) nogil:
+                int ldb, double beta, double* C, int ldc) noexcept nogil:
     gemm(
         TRANSPOSE if transA else NO_TRANSPOSE,
         TRANSPOSE if transB else NO_TRANSPOSE,
@@ -615,7 +615,7 @@ cdef void dgemm(bint transA, bint transB, int M, int N, int K,
 
 cdef void sgemm(bint transA, bint transB, int M, int N, int K,
                 float alpha, const float* A, int lda, const float* B,
-                int ldb, float beta, float* C, int ldc) nogil:
+                int ldb, float beta, float* C, int ldc) noexcept nogil:
     gemm(
         TRANSPOSE if transA else NO_TRANSPOSE,
         TRANSPOSE if transB else NO_TRANSPOSE,
@@ -627,12 +627,12 @@ cdef void sgemm(bint transA, bint transB, int M, int N, int K,
 
 
 cdef void saxpy(int N, float alpha, const float* X, int incX,
-                float* Y, int incY) nogil:
+                float* Y, int incY) noexcept nogil:
     axpyv(NO_CONJUGATE, N, alpha, X, incX, Y, incY)
 
 
 cdef void daxpy(int N, double alpha, const double* X, int incX,
-                double* Y, int incY) nogil:
+                double* Y, int incY) noexcept nogil:
     axpyv(NO_CONJUGATE, N, alpha, X, incX, Y, incY)
 
 


### PR DESCRIPTION
Hi!

Cython has now entered release 3.0 since last year, and one of the big breaking changes is that all functions that are not marked as `noexcept` are now expected to raise Python exceptions (as with `except *`); this was done to avoid silencing any potential exception.

This means that the current version of `cython-blis`, where the functions were not marked as `noexcept`, compiling with Cython 3.0, would result in the GIL being reacquired on every function call. 

Since none of the functions in the `cython-blis` code should raise exceptions, I just marked all of them `noexcept` to avoid implicit GIL reacquisition. This is still backward compatible with Cython `0.x`.