### PR TITLE
Update `setup.py` to build object files in parallel if requested

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -260,12 +260,8 @@ class ExtensionBuilder(build_ext, build_ext_options):
                     if "visibility=hidden" not in f
                 ]
                 specs.append(spec)
-        if self.parallel is None:
-            pool = ThreadPool(1)
-        elif self.parallel == 0:
-            pool = ThreadPool()
-        else:
-            pool = ThreadPool(self.parallel)
+        jobs = int(os.getenv("MAX_JOBS", "1")) if self.parallel is None else self.parallel
+        pool = ThreadPool(jobs or None)
         with pool:
             objects = pool.map(lambda spec: self.build_object(env=env, **spec), specs)
         return objects


### PR DESCRIPTION
Hi again!

Since the best way to install `cython-blis` is to compile it from source to take advantage of the machine architecture. In the case of our HPC cluster, I end up re-installing `cython-blis` on each node executor at the start of each job to make sure I'm using optimized code, but this takes a bit of time.

Given that BLIS has a lot of source files, the build process can be parallelized easily. I just changed the logic of the `ExtensionBuilder.compile_objects` code to actually invoke the compiler to build objects in parallel with a [`ThreadPool`](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.ThreadPool), based on the `parallel` flag of the command line (which is a default `build_ext` option), or using the `MAX_JOBS` environment variable (similar to what `torch` and `flash-attn` are doing). 

By default, I left the job count to `1`, so that parallel compilation happens only if enabled. Using 4 threads, the compilation is about twice faster:

```console
MAX_JOBS="4" pip install blis --no-binary=blis 
```



