### PR TITLE
Add support for free-threading & Python 3.14

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Debug env
         run: env
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.3
+        uses: pypa/cibuildwheel@v3.1.2
         env:
           CIBW_ARCHS_LINUX: auto
           DISTUTILS_USE_SDK: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-2019]
-        python_version: ["3.9", "3.10", "3.11", "3.12"]
+        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/blis/cy.pyx
+++ b/blis/cy.pyx
@@ -1,5 +1,6 @@
 # cython: infer_types=True
 # cython: boundscheck=False
+# cython: freethreading_compatible=True
 # Copyright ExplsionAI GmbH, released under BSD.
 
 import atexit

--- a/blis/py.pyx
+++ b/blis/py.pyx
@@ -1,4 +1,5 @@
 # cython: boundscheck=False
+# cython: freethreading_compatible=True
 # Copyright ExplsionAI GmbH, released under BSD.
 cimport numpy as np
 from . cimport cy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools",
-    "cython>=3.0,<4.0",
+    "cython>=3.1,<4.0",
     "numpy>=1.19.3,<3.0.0"
 ]
 build-backend = "setuptools.build_meta"
@@ -10,9 +10,9 @@ build-backend = "setuptools.build_meta"
 build = "*"
 skip = "pp* cp36* cp37* cp38* cp39*"
 test-skip = ""
-free-threaded-support = false
 
 archs = ["native"]
+enable = ["cpython-freethreading"]
 
 build-frontend = "default"
 config-settings = {}

--- a/setup.py
+++ b/setup.py
@@ -302,7 +302,7 @@ with chdir(root):
 
 setup(
     setup_requires=[
-        "cython>=3.0,<4.0",
+        "cython>=3.1,<4.0",
         "numpy>=2.0.0,<3.0.0",
     ],
     install_requires=[
@@ -324,7 +324,7 @@ setup(
         ],
         language_level=2,
     ),
-    python_requires=">=3.6,<3.14",
+    python_requires=">=3.6,<3.15",
     cmdclass={"build_ext": ExtensionBuilder},
     package_data={"": ["*.json", "*.jsonl", "*.pyx", "*.pxd"]},
     name="blis",
@@ -348,6 +348,8 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: Scientific/Engineering",
     ],
 )


### PR DESCRIPTION
Hey folks! 👋 

I did some testing on the free-threaded build and it seems that blis is in a good state. There's no global state and I couldn't identify any potential thread safety issues.

So I'm opening this PR to start build wheels for the free-threaded build as well as 3.14. In more detail, this PR does the following:
- Upgrades Cython to >=3.1, which is the version that supports free-threading
- Enables free-threading support in cibuildwheel so that free-threaded wheels are built
- Changes accepted Python versions to <3.15