### PR TITLE
Bump up gh actions versions

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       # See https://cibuildwheel.pypa.io/en/1.x/cpp_standards/
       - uses: ilammy/msvc-dev-cmd@v1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       # Install LLVM 18 on Windows
       - name: Install LLVM 18 on Windows
@@ -37,8 +37,9 @@ jobs:
       #    platforms: all
       - name: Debug env
         run: env
+
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.2.1
+        uses: pypa/cibuildwheel@v3.3.0
         env:
           CIBW_ARCHS_LINUX: auto
           DISTUTILS_USE_SDK: 1
@@ -52,7 +53,8 @@ jobs:
           package-dir: .
           output-dir: wheelhouse
           config-file: "{package}/pyproject.toml"
-      - uses: actions/upload-artifact@v4
+
+      - uses: actions/upload-artifact@v5
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
@@ -61,14 +63,16 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build sdist
         run: pipx run build --sdist
-      - uses: actions/upload-artifact@v4
+
+      - uses: actions/upload-artifact@v5
         with:
           name: cibw-sdist
           path: dist/*.tar.gz
+
   create_release:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
@@ -99,12 +103,14 @@ jobs:
           echo "FULL_TAG=$TAG_NAME" >> $GITHUB_ENV
           echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
           echo "IS_PRERELEASE=$IS_PRERELEASE" >> $GITHUB_ENV
-      - uses: actions/download-artifact@v4
+
+      - uses: actions/download-artifact@v5
         with:
           # unpacks all CIBW artifacts into dist/
           pattern: cibw-*
           path: dist
           merge-multiple: true
+      
       - name: Create Draft Release
         id: create_release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/generate_jsonl.yml
+++ b/.github/workflows/generate_jsonl.yml
@@ -26,12 +26,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: 'recursive'
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         architecture: arm64
@@ -44,7 +44,7 @@ jobs:
       run: |
         ./bin/generate-make-jsonl linux cortexa57 --export
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: jsonl-${{ runner.os }}
         path: artifacts/
@@ -53,7 +53,7 @@ jobs:
     # Optional: Automatically commit artifacts
     #- name: Download all artifacts
     #  if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    #  uses: actions/download-artifact@v4
+    #  uses: actions/download-artifact@v5
     #  with:
     #    path: downloaded-artifacts
     #- name: Commit artifacts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Configure Python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
           architecture: x64
@@ -73,6 +73,7 @@ jobs:
           clang --version
           python -m build --wheel
         shell: cmd
+
       - name: Build wheel (Mac)
         if: startsWith(matrix.os, 'macos')
         run: |


### PR DESCRIPTION
A more thorough CI run is available at https://github.com/explosion/cython-blis/pull/130
Fix for azure failures is in #129 