### PR TITLE
Fix cibuildwheel for MacOS x64

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, macos-13, macos-14, ubuntu-24.04-arm, windows-latest]
+        # macos-15-intel is an intel runner, macos-latest is apple silicon
+        os: [ubuntu-latest, macos-15-intel, macos-latest, ubuntu-24.04-arm, windows-latest]
 
     steps:
       # See https://cibuildwheel.pypa.io/en/1.x/cpp_standards/


### PR DESCRIPTION
macos-13 has been browned out.
Full CI run can be seen at https://github.com/crusaderky/cython-blis/pull/1