### PR TITLE
Test oldest NumPy runtime

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs:
           - windows-latest  # x64
         python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         cc: ['']  # default: gcc on Linux; clang on Mac/Windows
+        numpy-runtime: ['']  # default: latest version
         include:
           # Note: default compiler for Linux is gcc. cibuildwheel uses gcc.
           # FIXME: clang crashes on ARM Linux
@@ -39,6 +40,23 @@ jobs:
           - os: ubuntu-latest
             python_version: "3.14"
             cc: clang
+          # Test oldest runtime version of NumPy.
+          # Note that we always use the latest available version for building.
+          - os: ubuntu-latest
+            python_version: "3.10"
+            numpy-runtime: "1.21.2"
+          - os: ubuntu-24.04-arm
+            python_version: "3.10"
+            numpy-runtime: "1.21.3"
+          - os: macos-15-intel
+            python_version: "3.10"
+            numpy-runtime: "1.21.3"
+          - os: macos-latest
+            python_version: "3.10"
+            numpy-runtime: "1.21.3"
+          - os: windows-latest
+            python_version: "3.10"
+            numpy-runtime: "1.21.3"
 
     runs-on: ${{ matrix.os }}
 
@@ -108,9 +126,17 @@ jobs:
           python -m pip uninstall -y -r installed.txt
 
       - name: Install wheel
+        if: matrix.numpy-runtime == ''
         shell: bash
         run: |
           python -m pip install dist/*.whl
+
+      - name: Install wheel with pinned NumPy
+        if: matrix.numpy-runtime != ''
+        shell: bash
+        run: |
+          python -m pip install numpy==${{ matrix.numpy-runtime }}
+          python -m pip install --no-deps dist/*.whl
 
       - name: Delete source directory
         shell: bash
@@ -123,8 +149,7 @@ jobs:
           python -c "import $MODULE_NAME" -Werror
 
       - name: Install test requirements
-        run: |
-          python -m pip install -U -r requirements.txt
+        run: python -m pip install -r requirements.txt
 
       - name: Run tests
         shell: bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # Test requirements
 numpy>=1.21.2
 pytest
-cython>=3.0,<4.0
 hypothesis>=4.0.0,<7.0.0


### PR DESCRIPTION
Add unit tests vs. NumPy 1.21 at runtime.
**Out of scope:** test oldest supported NumPy _build_ version