### PR TITLE
Run pytest in cibuildwheel

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,5 +157,4 @@ jobs:
         run: python -m pip install -r requirements.txt
 
       - name: Run tests
-        shell: bash
-        run: pytest tests -Werror
+        run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
 build = "*"
 skip = "cp38* cp39* cp3??t-*"
-test-skip = ""
 
 archs = ["native"]
 
@@ -24,9 +23,10 @@ before-all = ""
 before-build = ""
 repair-wheel-command = ""
 
-test-command = ""
+test-command = "pytest"
+test-sources = ["tests", "pyproject.toml"]
 before-test = ""
-test-requires = []
+test-requires = ["pytest", "hypothesis"]
 test-extras = []
 
 container-engine = "docker"
@@ -56,3 +56,9 @@ repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest
 [tool.cibuildwheel.windows]
 
 [tool.cibuildwheel.pyodide]
+
+[tool.pytest.ini_options]
+addopts = "--strict-markers --strict-config -v -r sxfE --color=yes --durations=10"
+python_files = ["test_*.py"]
+testpaths = ["tests"]
+filterwarnings = ["error"]


### PR DESCRIPTION
Run the test suite inside cibuildwheel, in addition to test CI.

This is important to verify cibuildwheel-specific nuance such as repair-wheel/delocate, or such as Alpine Linux (musllinux) compatibility, which otherwise remains untested.

The extra runtime for the test suite is 5~15s so it's not an issue.

Code review at https://github.com/crusaderky/cython-blis/pull/6