### PR TITLE
Tests overhaul

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,3 +63,7 @@ addopts = "--strict-markers --strict-config -v -r sxfE --color=yes --durations=1
 python_files = ["test_*.py"]
 testpaths = ["tests"]
 filterwarnings = ["error"]
+markers = [
+  # Needed when pytest-run-parallel is not installed
+  "thread_unsafe: Run test in single thread in pytest-run-parallel"
+]

--- a/tests/blis_tests_common.py
+++ b/tests/blis_tests_common.py
@@ -1,4 +1,5 @@
 # Copyright ExplosionAI GmbH, released under BSD.
+from concurrent.futures import ThreadPoolExecutor
 from hypothesis import settings
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
@@ -23,3 +24,12 @@ def ndarrays(shape, lo, hi, dtype):
     width = int(dtype[5:])
     elements = st.floats(min_value=lo, max_value=hi, width=width)
     return arrays(dtype, shape=shape, elements=elements)
+
+
+def run_threaded(func, max_workers=8, outer_iterations=2):
+    """Runs a function many times in parallel"""
+    with ThreadPoolExecutor(max_workers=max_workers) as tpe:
+        for _ in range(outer_iterations):
+            futures = [tpe.submit(func) for _ in range(max_workers)]
+            for f in futures:
+                f.result()

--- a/tests/test_dotv.py
+++ b/tests/test_dotv.py
@@ -5,7 +5,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 from numpy.testing import assert_allclose
 
-from blis_tests_common import dtypes_tols, ndarrays
+from blis_tests_common import dtypes_tols, ndarrays, run_threaded
 from blis.py import dotv
 
 
@@ -29,3 +29,17 @@ def test_memoryview_noconj(arrays):
     numpy_result = A.dot(B)
     result = dotv(A, B)
     assert_allclose(result, numpy_result, atol=atol, rtol=rtol)
+
+
+@given(dotv_arrays())
+@pytest.mark.thread_unsafe(reason="Uses run_threaded")
+def test_threads_share_input(arrays):
+    """Test when multiple threads share the same input arrays."""
+    A, B, atol, rtol = arrays
+    numpy_result = A.dot(B)
+
+    def f():
+        result = dotv(A, B)
+        assert_allclose(result, numpy_result, atol=atol, rtol=rtol)
+
+    run_threaded(f)

--- a/tests/test_gemm.py
+++ b/tests/test_gemm.py
@@ -5,7 +5,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 from numpy.testing import assert_allclose
 
-from blis_tests_common import dtypes_tols, ndarrays
+from blis_tests_common import dtypes_tols, ndarrays, run_threaded
 from blis.py import gemm
 
 
@@ -40,3 +40,18 @@ def test_memoryview_notrans(arrays):
     C = np.zeros_like(numpy_result)  # (l, n)
     gemm(A, B, out=C)
     assert_allclose(C, numpy_result, atol=atol, rtol=rtol)
+
+
+@given(gemm_arrays())
+@pytest.mark.thread_unsafe(reason="Uses run_threaded")
+def test_threads_share_input(arrays):
+    """Test when multiple threads share the same input arrays."""
+    A, B, atol, rtol = arrays
+    numpy_result = A.dot(B)
+
+    def f():
+        C = np.zeros_like(numpy_result)  # (l, n)
+        gemm(A, B, out=C)
+        assert_allclose(C, numpy_result, atol=atol, rtol=rtol)
+
+    run_threaded(f)


### PR DESCRIPTION
This PR thoroughly revisits the test suite. It's made of several commits, each with individual comments:

- [Tweak test tolerances](https://github.com/explosion/cython-blis/pull/143/commits/0035444abc6aca91c701d778e5eae1d8cbfff9c5)
  - Tighten tolerance for float64 from 1e-3 ~ 1e-4 to 1e-9.
  - Relax tolerance for float32 to 1e-2, as increasing the number of valid examples lead to the discovery of dotv: float32 rounding error is 10x of NumPy  (#142).
  - Swap actual <-> desired in assert_almost_equal, as the two are not symmetric.
- [Tweak strategies ranges](https://github.com/explosion/cython-blis/pull/143/commits/820905ccc4e0774b56c72aab6807c2b5ed54f83a)
  - Add test coverage for arrays of size 1.
  - Remove unused, confusing default parameters from custom strategies.
- [Add central control for number of examples tested](https://github.com/explosion/cython-blis/pull/143/commits/3d0f9ad1a680de8ad2e8d3e4b1cec77b3fc8aa9d)
  This is meant to be tampered with locally for more thorough (slower) tests.
- [New test for dotv invalid use case](https://github.com/explosion/cython-blis/pull/143/commits/0fe793e469de457bedfa523388e40d386de36366)
  Mirrors same test in test_gemm.py.
- [Overaul hypothesis strategies](https://github.com/explosion/cython-blis/pull/143/commits/5c90b6938becbb97e8df7110e01ae0a746414bb5)
  - Improve readability.
  - Given infinite hypothesis examples, this commit does not introduce any functional changes.
    However, given a fixed and relatively low max_examples setting, it substantially increases test coverage:
    1. It prevents examples that were previously skipped by assume(). According to `pytest --hypothesis-show-statistics`, these were ~10% for dotv and ~20% for gemm.
    2. It prevents examples that ended up being duplicates due to trimming. For example, in dotv, hypothesis could previously generate examples e.g. `A=[1,2,3,4], B=[5,6]` and `A=[1,2], B=[5,6,7,8]`; both would get trimmed to `A=[1,2], B=[5,6]`.
    3. In gemm, it removes an entire degree of freedom by removing unused variable `out_col`, which again would result in duplicate examples.
- [Add threading tests for shared input](https://github.com/explosion/cython-blis/pull/143/commits/555d35f0c8568c2040bc5cd5f6dc3059ef771580)
Given input arrays that are shared between multiple threads, test that you can run dotv and gemm on them in parallel from multiple threads.