### PR TITLE
Increment version

### DIFF
--- a/blis/about.py
+++ b/blis/about.py
@@ -5,7 +5,7 @@
 # https://github.com/pypa/warehouse/blob/master/warehouse/__about__.py
 
 __name__ = "blis"
-__version__ = "1.3.3"
+__version__ = "1.3.4.dev0"
 __summary__ = (
     "The Blis BLAS-like linear algebra library, as a self-contained C-extension."
 )


### PR DESCRIPTION
FYI @honnibal due to the introduction of nighly builds, it would be best from now on 
- immediately before a release, bump version to the release version and remove the dev marker, e.g. from `1.3.4.dev0` to `1.3.4`
- immmediately _after_ a release, bump version again to re-add the dev marker, e.g. `1.3.5.dev0`

Alternatively to the above the project could switch to SCM versioning